### PR TITLE
Filter tracking of tweets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ In your peer boot-up namespace:
 | :twitter/access-token        | String              | API key      |
 | :twitter/access-secret       | String              | API key      |
 | :twitter/keep-keys           | [Any]               | Keys to keep in the tweet map after deconstructing the POJO tweet. Defaults to `[:id :lang :text]`. `:all` will keep all the tweet's keys|
+| :twitter/track               | String              | String of words that you to get the Twitter API to filter against.|
 
 #### Contributing
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In your peer boot-up namespace:
 | :twitter/access-token        | String              | API key      |
 | :twitter/access-secret       | String              | API key      |
 | :twitter/keep-keys           | [Any]               | Keys to keep in the tweet map after deconstructing the POJO tweet. Defaults to `[:id :lang :text]`. `:all` will keep all the tweet's keys|
-| :twitter/track               | String              | String of words that you to get the Twitter API to filter against.|
+| :twitter/track               | [String]              | An array of strings that you to track against the firehose.|
 
 #### Contributing
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.onyxplatform/onyx-twitter "0.9.15.0-SNAPSHOT"
+(defproject org.onyxplatform/onyx-twitter "0.9.15.0"
   :description "Onyx plugin for Twitter"
   :url "https://github.com/onyx-platform/onyx-twitter"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.onyxplatform/onyx-twitter "0.9.15.0"
+(defproject org.onyxplatform/onyx-twitter "0.9.15.0-SNAPSHOT"
   :description "Onyx plugin for Twitter"
   :url "https://github.com/onyx-platform/onyx-twitter"
   :license {:name "Eclipse Public License"

--- a/src/onyx/tasks/twitter.clj
+++ b/src/onyx/tasks/twitter.clj
@@ -8,6 +8,7 @@
    :twitter/access-token s/Str
    :twitter/access-secret s/Str
    (s/optional-key :twitter/keep-keys) (s/either s/Keyword [s/Any])
+   (s/optional-key :twitter/track) [s/Str]
    (os/restricted-ns :twitter) s/Any})
 
 (s/defn stream

--- a/src/onyx/twitter/information_model.cljc
+++ b/src/onyx/twitter/information_model.cljc
@@ -25,6 +25,10 @@
       :twitter/keep-keys
       {:doc "Keys to keep in the tweet map after deconstructing the POJO tweet. Defaults to `[:id :lang :text]`. `:all` will keep all the tweet's keys."
        :default [:id :lang :text]
+       :type :vector}
+
+      :twitter/track
+      {:doc "An array of strings that you to get the Twitter API to track."
        :type :vector}}}}
 
    :lifecycle-entry
@@ -39,4 +43,5 @@
      :twitter/consumer-secret
      :twitter/access-token
      :twitter/access-secret
-     :twitter/keep-keys]}})
+     :twitter/keep-keys
+     :twitter/track]}})


### PR DESCRIPTION
Additional feature to the Twitter plugin to specify an array of strings to track against the Twitter Stream. If not specified in the catalog then the plugin will use the default sample from the firehose instead.
